### PR TITLE
Do not try to reload the SSH daemon in Darwin/MacOS

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,4 @@
     name: sshd
     state: reloaded
   become: true
+  when: ansible_facts["os_family"] != "Darwin"


### PR DESCRIPTION
Thank you very much for sharing this awesome module!
It works flawlessy for me, even under MacOS.

This commit fixes just a minor wrinkles in the process:
The service Ansible module is not implemented under MacOS
so trying to execute it would throw an error.

Moreover the reload (at least on MacOS) is not necessary as
the signed SSH host key will be presented anyway at the first
connection.